### PR TITLE
Fixed issue #83

### DIFF
--- a/app/src/server/handlers.go
+++ b/app/src/server/handlers.go
@@ -83,7 +83,7 @@ func (s *Server) userTimeline(w http.ResponseWriter, r *http.Request) {
 
 	userID := (user.(*types.User)).UserID
 
-	if err != nil && err.Error() == "record not found" {
+	if err != nil && err == gorm.ErrRecordNotFound {
 		error_response := types.RequestData{
 			Title:           "title",
 			RequestEndpoint: "userTimeline",

--- a/app/src/static/templates/timeline.html
+++ b/app/src/static/templates/timeline.html
@@ -3,7 +3,9 @@
 <h2>
   {{ if eq "timeline" .RequestEndpoint }}
     Public Timeline
-  {{ else if eq "userTimeline" .RequestEndpoint }}
+  {{ else if and (eq "userTimeline" .RequestEndpoint) (.HasError) }}
+    <div class=error><strong>Error:</strong> {{ .ErrorMsg }}</div>
+  {{ else if (eq "userTimeline" .RequestEndpoint) }}
     {{ .UserProfile }}'s Timeline
   {{ else }}
     My Timeline
@@ -17,6 +19,8 @@
       {{ else if .Followed }}
         You are currently following this user.
         <a class=unfollow href="/{{.UserProfile}}/unfollow">Unfollow user</a>.
+      {{ else if and (not .Followed) (.HasError) }}
+      <a class=follow href="/public">Go back to the public timeline</a>.
       {{ else }}
         You are not yet following this user.
         <a class=follow href="/{{.UserProfile}}/follow">Follow user</a>.
@@ -45,7 +49,7 @@
           <small>&mdash; {{ .PublishedDate}}</small>
         </li>
       {{end}}
-    {{else}}
+    {{else if not .HasError}}
     <em>There's no message so far.</em>
     {{end}}
   </ul>

--- a/app/src/types/RequestData.go
+++ b/app/src/types/RequestData.go
@@ -8,4 +8,6 @@ type RequestData struct {
 	SessionUser     string
 	UserProfile     string
 	Followed        bool
+	HasError        bool
+	ErrorMsg        string
 }


### PR DESCRIPTION
Fixed issue #83 Loading a page with faulty username results in panic. 

- Now shows a nice error message and asks the user to redirect to public timeline. 